### PR TITLE
Update hamcrest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,14 +48,14 @@
  <repositories>
   <repository>
    <id>repo.jenkins-ci.org</id>
-   <url>http://repo.jenkins-ci.org/public/</url>
+   <url>https://repo.jenkins-ci.org/public/</url>
   </repository>
  </repositories>
 
  <pluginRepositories>
   <pluginRepository>
    <id>repo.jenkins-ci.org</id>
-   <url>http://repo.jenkins-ci.org/public/</url>
+   <url>https://repo.jenkins-ci.org/public/</url>
   </pluginRepository>
  </pluginRepositories>
 
@@ -261,6 +261,7 @@
    <plugin>
     <groupId>org.apache.maven.plugins</groupId>
     <artifactId>maven-surefire-plugin</artifactId>
+    <version>3.1.2</version>
     <configuration>
      <forkCount>1</forkCount>
      <reuseForks>false</reuseForks>

--- a/pom.xml
+++ b/pom.xml
@@ -233,8 +233,8 @@
   </dependency>
   <dependency>
    <groupId>org.hamcrest</groupId>
-   <artifactId>hamcrest-core</artifactId>
-   <version>1.3</version>
+   <artifactId>hamcrest</artifactId>
+   <version>2.2</version>
    <scope>test</scope>
   </dependency>
  </dependencies>


### PR DESCRIPTION
 _🤖 This is an automatic PR for replacing the deprecated 'hamcrest-*' modules with 'hamcrest'._

  All deprecated modules' code has been merged into 'hamcrest'.
  Consumers of `hamcrest-*` should replace the dependency with `hamcrest`, which is the drop-in module containing the code of the deprecated `hamcrest-*` modules.

  Ping `@NotMyFault` if you have questions.

  _[script source](https://github.com/NotMyFault/jenkins-version-updater)_

Edit: Future build failures were already present on the master branch.